### PR TITLE
Minor refactor

### DIFF
--- a/pkg/gui/mergeconflicts/merge_conflict.go
+++ b/pkg/gui/mergeconflicts/merge_conflict.go
@@ -42,8 +42,7 @@ func (s Selection) isIndexToKeep(conflict *mergeConflict, i int) bool {
 		return false
 	}
 
-	selectionStart, selectionEnd := s.bounds(conflict)
-	return selectionStart < i && i < selectionEnd
+	return s.selected(conflict, i)
 }
 
 func (s Selection) bounds(c *mergeConflict) (int, int) {

--- a/pkg/gui/mergeconflicts/merge_conflict.go
+++ b/pkg/gui/mergeconflicts/merge_conflict.go
@@ -1,0 +1,79 @@
+package mergeconflicts
+
+// mergeConflict : A git conflict with a start, ancestor (if exists), target, and end corresponding to line
+// numbers in the file where the conflict markers appear.
+// If no ancestor is present (i.e. we're not using the diff3 algorithm), then
+// the `ancestor` field's value will be -1
+type mergeConflict struct {
+	start    int
+	ancestor int
+	target   int
+	end      int
+}
+
+func (c *mergeConflict) hasAncestor() bool {
+	return c.ancestor >= 0
+}
+
+func (c *mergeConflict) isMarkerLine(i int) bool {
+	return i == c.start ||
+		i == c.ancestor ||
+		i == c.target ||
+		i == c.end
+}
+
+type Selection int
+
+const (
+	TOP Selection = iota
+	MIDDLE
+	BOTTOM
+	ALL
+)
+
+func (s Selection) isIndexToKeep(conflict *mergeConflict, i int) bool {
+	// we're only handling one conflict at a time so any lines outside this
+	// conflict we'll keep
+	if i < conflict.start || conflict.end < i {
+		return true
+	}
+
+	if conflict.isMarkerLine(i) {
+		return false
+	}
+
+	selectionStart, selectionEnd := s.bounds(conflict)
+	return selectionStart < i && i < selectionEnd
+}
+
+func (s Selection) bounds(c *mergeConflict) (int, int) {
+	switch s {
+	case TOP:
+		if c.hasAncestor() {
+			return c.start, c.ancestor
+		} else {
+			return c.start, c.target
+		}
+	case MIDDLE:
+		return c.ancestor, c.target
+	case BOTTOM:
+		return c.target, c.end
+	case ALL:
+		return c.start, c.end
+	}
+
+	panic("unexpected selection for merge conflict")
+}
+
+func (s Selection) selected(c *mergeConflict, idx int) bool {
+	start, end := s.bounds(c)
+	return start < idx && idx < end
+}
+
+func availableSelections(c *mergeConflict) []Selection {
+	if c.hasAncestor() {
+		return []Selection{TOP, MIDDLE, BOTTOM}
+	} else {
+		return []Selection{TOP, BOTTOM}
+	}
+}

--- a/pkg/gui/mergeconflicts/rendering.go
+++ b/pkg/gui/mergeconflicts/rendering.go
@@ -16,7 +16,7 @@ func ColoredConflictFile(content string, state *State, hasFocus bool) string {
 	var outputBuffer bytes.Buffer
 	for i, line := range utils.SplitLines(content) {
 		textStyle := theme.DefaultTextColor
-		if i == conflict.start || i == conflict.ancestor || i == conflict.target || i == conflict.end {
+		if conflict.isMarkerLine(i) {
 			textStyle = style.FgRed
 		}
 
@@ -36,18 +36,6 @@ func shiftConflict(conflicts []*mergeConflict) (*mergeConflict, []*mergeConflict
 }
 
 func shouldHighlightLine(index int, conflict *mergeConflict, selection Selection) bool {
-	switch selection {
-	case TOP:
-		if conflict.hasAncestor() {
-			return index >= conflict.start && index <= conflict.ancestor
-		} else {
-			return index >= conflict.start && index <= conflict.target
-		}
-	case MIDDLE:
-		return index >= conflict.ancestor && index <= conflict.target
-	case BOTTOM:
-		return index >= conflict.target && index <= conflict.end
-	default:
-		return false
-	}
+	selectionStart, selectionEnd := selection.bounds(conflict)
+	return index >= selectionStart && index <= selectionEnd
 }


### PR DESCRIPTION
@Ryooooooga I have a bad habit of doing a PR review that ends up turning into a bit of a refactor. In times like this rather than paste my changes inside your PR I put up a PR as a suggested refactor to be merged into your branch if accepted. Let me know if you disagree with anything here :)

I've made a couple changes here:
* I've moved some selection-specific code into methods of the Selection type
* the Selection type depends on mergeConflict but not vice-versa, so I've moved the `availableSelections` method out of the mergeConflict struct (just to avoid a circular dependency)
* the `bounds` method centralises our code for working out which lines are selected
* isMarkerLine centralises some code that appeared in two places
* the mergeConflict struct now lives in its own file because the state file was getting a bit crowded. I'm open to Selection having its own file too

I played around with start, ancestor, target, end, all just being combined into a slice of ints inside the mergeConflict struct but that ended up more complex than it was worth